### PR TITLE
Add the option to detect YouTube URLs and return additional video info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lita-youtube-me
 
-Replies with a video that matches a string.
+Replies with a video that matches a string. Optionally detects YouTube URLs and returns title, duration, etc.
 
 ## Installation
 
@@ -10,11 +10,47 @@ Add lita-youtube to your Lita instance's Gemfile:
 gem "lita-youtube-me"
 ```
 
+## Configuration
+
+### Optional attributes
+* `video_info` (boolean) - When set to `true`, Lita will return additional information (title, duration, etc.) about the video. Default: `false`
+* `detect_urls` (boolean) - When set to `true`, Lita will return additional information about any YouTube URLs it detects. Default: `false`
+
+### Example
+``` ruby
+Lita.configure do |config|
+  config.handlers.youtube_me.video_info = true
+  config.handlers.youtube_me.detect_urls = true
+end
+```
+
 ## Usage
 
+The following are all equivalent ways of asking Lita to search for a video about "soccer":
 ```
 @bot: youtube me soccer
 @bot: youtube soccer
+@bot: yt me soccer
+@bot: yt soccer
+```
+
+Lita's default response will be a YouTube URL:
+```
+<bot> https://www.youtube.com/watch?v=SZJldG6bP1s
+```
+
+Enabling the config variable `video_info` will add another line to Lita's response:
+```
+<bot> https://www.youtube.com/watch?v=SZJldG6bP1s
+<bot> Soccer Kid Thug [0:23] by turdmalone on 2015-04-10 (49.5k views, 96% liked)
+```
+
+Enabling `detect_urls` will make Lita return information about any YouTube URLs it detects:
+```
+<jack> hey @jill check out the new game of thrones trailer https://www.youtube.com/watch?v=dQw4w9WgXcQ lol
+<bot> Rick Astley - Never Gonna Give You Up [3:33] by RickAstleyVEVO on 2009-10-25 (115.2M views, 94% liked)
+<jill> nope, not falling for it this time!
+<jack> drat
 ```
 
 ## License

--- a/lib/lita/handlers/youtube_me.rb
+++ b/lib/lita/handlers/youtube_me.rb
@@ -1,14 +1,22 @@
+require "date"
+
 module Lita
   module Handlers
     class YoutubeMe < Handler
       API_URL = "https://gdata.youtube.com/feeds/api/videos"
 
-      route(/youtube( me)? (.*)/i, :find_video, command: true, help: {
+      config :video_info, types: [TrueClass, FalseClass], default: false
+      config :detect_urls, types: [TrueClass, FalseClass], default: false
+
+      route(/^(?:youtube|yt)(?: me)?\s+(.*)/i, :find_video, command: true, help: {
         "youtube (me) QUERY" => "Gets a youtube video."
       })
+      # Detect YouTube links in non-commands and display video info
+      route(/\byoutube\.com\/watch\?v=([^?&#\s]+)/i, :display_info, command: false)
+      route(/\byoutu\.be\/([^?&#\s]+)/i, :display_info, command: false)
 
       def find_video(response)
-        query = response.matches[0][1]
+        query = response.matches[0][0]
         http_response = http.get(API_URL,
           q: query,
           orderBy: "relevance",
@@ -19,9 +27,50 @@ module Lita
         video = videos.sample
         video["link"].each do |link|
           if link["rel"] == "alternate" && link["type"] == "text/html"
-            response.reply link["href"]
+            response.reply link["href"].split("&").first
           end
         end
+        if config.video_info
+          response.reply info(video)
+        end
+      end
+
+      def display_info(response)
+        if config.detect_urls
+          id = response.matches[0][0]
+          http_response = http.get("#{API_URL}/#{id}", alt: "json")
+          video = MultiJson.load(http_response.body)["entry"]
+          response.reply info(video)
+        end
+      end
+
+      def info(video)
+        title = video["title"]["$t"]
+        uploader = video["author"][0]["name"]["$t"]
+        date = DateTime.iso8601(video["published"]["$t"]).strftime("%F")
+
+        # Format time, only show hours if necessary
+        sec = video["media$group"]["yt$duration"]["seconds"].to_i
+        min = sec / 60
+        hr = min / 60
+        time = "%d:%02d" % [min, sec%60]
+        if hr > 0
+          time = "%d:%02d:%02d" % [hr, min%60, sec%60]
+        end
+
+        # Abbreviate view count, based on http://stackoverflow.com/a/2693484
+        n = video["yt$statistics"]["viewCount"].to_i
+        i = 0
+        while n >= 1e3 do
+          n /= 1e3
+          i += 1
+        end
+        views = "%.#{n.to_s.length>3?1:0}f%s" % [n.round(1), " kMBT"[i]]
+
+        # Calculate rating, accounting for YouTube's 1-5 score range
+        rating = "%.f" % [(video.fetch("gd$rating", {}).fetch("average", 1) - 1) / 4 * 100]
+
+        "#{title} [#{time}] by #{uploader} on #{date} (#{views.strip} views, #{rating}% liked)"
       end
     end
 

--- a/spec/lita/handlers/youtube_me_spec.rb
+++ b/spec/lita/handlers/youtube_me_spec.rb
@@ -7,10 +7,54 @@ describe Lita::Handlers::YoutubeMe, lita_handler: true do
   it { is_expected.to route_command("youtube something") }
   it { is_expected.to route_command("youtube something").to(:find_video) }
 
+  it { is_expected.to route_command("yt me something") }
+  it { is_expected.to route_command("yt me something").to(:find_video) }
+
+  it { is_expected.to route_command("yt something") }
+  it { is_expected.to route_command("yt something").to(:find_video) }
+
+  it { is_expected.to route("https://www.youtube.com/watch?v=nG7RiygTwR4&feature=youtube_gdata") }
+  it { is_expected.to route("https://www.youtube.com/watch?v=nG7RiygTwR4&feature=youtube_gdata").to(:display_info) }
+
+  it { is_expected.to route("taco https://youtu.be/nG7RiygTwR4?t=9m13s taco") }
+  it { is_expected.to route("taco https://youtu.be/nG7RiygTwR4?t=9m13s taco").to(:display_info) }
+
   it "can find a youtube video with a query" do
     send_command("youtube me soccer")
     expect(replies.count).to eq 1
     expect(replies.last).to_not be_nil
     expect(replies.last).to match(/youtube\.com/)
+  end
+
+  it "displays info for a requested video when the video_info config variable is true" do
+    registry.config.handlers.youtube_me.video_info = true
+    send_command("yt soccer")
+    expect(replies.count).to eq 2
+    expect(replies.first).to_not be_nil
+    expect(replies.first).to match(/youtube\.com/)
+    expect(replies.last).to_not be_nil
+    expect(replies.last).to match(/views/)
+  end
+
+  it "does not display info for a requested video when the video_info config variable is false" do
+    registry.config.handlers.youtube_me.video_info = false
+    send_command("youtube me soccer")
+    expect(replies.count).to eq 1
+    expect(replies.last).to_not be_nil
+    expect(replies.last).to match(/youtube\.com/)
+  end
+
+  it "displays video info for detected YouTube URLs when the detect_urls config variable is true" do
+    registry.config.handlers.youtube_me.detect_urls = true
+    send_message("taco taco https://www.youtube.com/watch?v=nG7RiygTwR4 taco taco")
+    expect(replies.count).to eq 1
+    expect(replies.first).to_not be_nil
+    expect(replies.first).to match(/10 minutes of DJ Mbenga saying Tacos \[10:02\] by RickFreeloader on 2011-09-12 \(\S+ views, \d+% liked\)/)
+  end
+
+  it "does not display video info for detected YouTube URLs when the detect_urls config variable is false" do
+    registry.config.handlers.youtube_me.detect_urls = false
+    send_message("https://www.youtube.com/watch?v=nG7RiygTwR4")
+    expect(replies.count).to eq 0
   end
 end


### PR DESCRIPTION
I've added the option for Lita to return additional information (title, duration, uploader, date, view count, and rating) about a requested video. This information can also be returned when Lita detects a YouTube URL in the channel. I expect that these will be useful features for people like myself who primarily use Lita on IRC, where most clients don't have inline video previews.

I also modified the find_video route to accept "yt" as an alias for "youtube" and also to require that the command be at the beginning of a message directed to Lita. This ensures that a user will not inadvertently trigger multiple responses by using another command containing the string "youtube" as an argument.
