### PR TITLE
Update to YouTube Data API v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ gem "lita-youtube-me"
 
 ## Configuration
 
+This plugin requires an API key for the [YouTube Data API (v3)](https://developers.google.com/youtube/v3/).
+
+``` ruby
+Lita.configure do |config|
+  config.handlers.youtube_me.api_key = "FooBarBazLuhrmann"
+end
+```
+
 ### Optional attributes
 * `video_info` (boolean) - When set to `true`, Lita will return additional information (title, duration, etc.) about the video. Default: `false`
 * `detect_urls` (boolean) - When set to `true`, Lita will return additional information about any YouTube URLs it detects. Default: `false`
 
-### Example
 ``` ruby
 Lita.configure do |config|
   config.handlers.youtube_me.video_info = true

--- a/lita-youtube-me.gemspec
+++ b/lita-youtube-me.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "lita", ">= 4.0"
+  spec.add_runtime_dependency "iso8601", ">= 0.8.6"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/lita/handlers/youtube_me_spec.rb
+++ b/spec/lita/handlers/youtube_me_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Lita::Handlers::YoutubeMe, lita_handler: true do
+  before do
+    registry.config.handlers.youtube_me.api_key = ENV["YOUTUBE_KEY"]
+  end
+
   it { is_expected.to route_command("youtube me something") }
   it { is_expected.to route_command("youtube me something").to(:find_video) }
 
@@ -54,6 +58,25 @@ describe Lita::Handlers::YoutubeMe, lita_handler: true do
 
   it "does not display video info for detected YouTube URLs when the detect_urls config variable is false" do
     registry.config.handlers.youtube_me.detect_urls = false
+    send_message("https://www.youtube.com/watch?v=nG7RiygTwR4")
+    expect(replies.count).to eq 0
+  end
+
+  it "does not send a message when the detected YouTube URL does not lead to a valid video" do
+    registry.config.handlers.youtube_me.detect_urls = true
+    send_message("https://www.youtube.com/watch?v=foo")
+    expect(replies.count).to eq 0
+  end
+
+  it "does not return a video in response to a query when the API key is invalid" do
+    registry.config.handlers.youtube_me.api_key = "this key doesn't work"
+    send_command("youtube me soccer")
+    expect(replies.count).to eq 0
+  end
+
+  it "does not display video info for detected YouTube URLs when the API key is invalid" do
+    registry.config.handlers.youtube_me.detect_urls = true
+    registry.config.handlers.youtube_me.api_key = "this key doesn't work"
     send_message("https://www.youtube.com/watch?v=nG7RiygTwR4")
     expect(replies.count).to eq 0
   end


### PR DESCRIPTION
YouTube recently stopped supporting v2 of their Data API, which broke video search and info in lita-youtube-me. I've updated the plugin to work with v3.

Please note that running rspec will require you to export your YouTube API key:

```
YOUTUBE_KEY='your key here' bundle exec rspec
```
