### PR TITLE
Fix a bug where the handler attempted to return a playlist, resulting in an invalid URL

### DIFF
--- a/lib/lita/handlers/youtube_me.rb
+++ b/lib/lita/handlers/youtube_me.rb
@@ -28,7 +28,7 @@ module Lita
           key: config.api_key
         )
         return if http_response.status != 200
-        videos = MultiJson.load(http_response.body)["items"]
+        videos = MultiJson.load(http_response.body)["items"].select { |v| v["id"].key?("videoId") }
         video = videos.sample
         id = video["id"]["videoId"]
         response.reply "https://www.youtube.com/watch?v=#{id}"

--- a/spec/lita/handlers/youtube_me_spec.rb
+++ b/spec/lita/handlers/youtube_me_spec.rb
@@ -30,6 +30,13 @@ describe Lita::Handlers::YoutubeMe, lita_handler: true do
     expect(replies.last).to match(/youtube\.com/)
   end
 
+  it "does not attempt to return a playlist" do
+    send_command("youtube babbletron birds")
+    expect(replies.count).to eq 1
+    expect(replies.last).to_not be_nil
+    expect(replies.last).not_to match(/^https:\/\/www\.youtube\.com\/watch\?v=$/)
+  end
+
   it "displays info for a requested video when the video_info config variable is true" do
     registry.config.handlers.youtube_me.video_info = true
     send_command("yt soccer")


### PR DESCRIPTION
I've filtered the `videos` list to make sure it has the key `"videoId"`. Playlists have `"playlistId"` instead, which prevented the handler from constructing a valid URL.
