### PR TITLE
Add a config option to return the top result for a video search

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ end
 ### Optional attributes
 * `video_info` (boolean) - When set to `true`, Lita will return additional information (title, duration, etc.) about the video. Default: `false`
 * `detect_urls` (boolean) - When set to `true`, Lita will return additional information about any YouTube URLs it detects. Default: `false`
+* `top_result` (boolean) - When set to `true`, Lita will return the top result in response to a video search. Default: `false`, which returns a random result selected from the top 15.
 
 ``` ruby
 Lita.configure do |config|
   config.handlers.youtube_me.video_info = true
   config.handlers.youtube_me.detect_urls = true
+  config.handlers.youtube_me.top_result = true
 end
 ```
 

--- a/lib/lita/handlers/youtube_me.rb
+++ b/lib/lita/handlers/youtube_me.rb
@@ -9,6 +9,7 @@ module Lita
       config :api_key, type: String, required: true
       config :video_info, types: [TrueClass, FalseClass], default: false
       config :detect_urls, types: [TrueClass, FalseClass], default: false
+      config :top_result, types: [TrueClass, FalseClass], default: false
 
       route(/^(?:youtube|yt)(?: me)?\s+(.*)/i, :find_video, command: true, help: {
         "youtube (me) QUERY" => "Gets a YouTube video."
@@ -29,7 +30,7 @@ module Lita
         )
         return if http_response.status != 200
         videos = MultiJson.load(http_response.body)["items"]
-        video = videos.sample
+        video = config.top_result ? videos.first : videos.sample
         id = video["id"]["videoId"]
         response.reply "https://www.youtube.com/watch?v=#{id}"
         if config.video_info

--- a/spec/lita/handlers/youtube_me_spec.rb
+++ b/spec/lita/handlers/youtube_me_spec.rb
@@ -68,6 +68,12 @@ describe Lita::Handlers::YoutubeMe, lita_handler: true do
     expect(replies.count).to eq 0
   end
 
+  it "returns the top video in response to a query when the top_result config variable is true" do
+    registry.config.handlers.youtube_me.top_result = true
+    send_command("yt polica lay your cards out")
+    expect(replies.first).to match(/Rl03afAqeFQ/)
+  end
+
   it "does not return a video in response to a query when the API key is invalid" do
     registry.config.handlers.youtube_me.api_key = "this key doesn't work"
     send_command("youtube me soccer")


### PR DESCRIPTION
I added the configuration option `top_result`, which allows the user to specify that the top video result be returned if set to `true`. Random selection from the top 15 results is still the default.
